### PR TITLE
Symfony3 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "require": {
     "nikic/php-parser": "^2.1",
-    "symfony/console": "^2.7"
+    "symfony/console": ">=2.7 <4.0"
   },
   "autoload": {
     "psr-4": { "MD\\": "src/" }


### PR DESCRIPTION
Allow to use the version 3.x of the console component. No other change was needed.